### PR TITLE
chore: add initial skeleton for backend and frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.env
+.env.local
+*.log
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
 # StarpathVision
+
+StarpathVision is a single‑tenant fortune‑telling platform that mixes image
+recognition and large language models to produce tarot, coffee and dream
+readings. This repository contains a minimal skeleton for both the NestJS
+backend and the Next.js frontend.
+
+## Quickstart
+
+### 1. Start infrastructure
+
+```bash
+docker compose up -d db redis minio mailhog
+```
+
+Create a bucket named `starpathvision` in the MinIO console
+(`http://localhost:9001`).
+
+### 2. Backend
+
+```bash
+cd backend
+npm install
+cp .env.example .env
+npm run start:dev
+```
+
+The API runs at `http://localhost:4000/v1`.
+
+### 3. Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The web app is available at `http://localhost:3000`.
+
+This skeleton contains only stub logic but wires together file uploads,
+tarot card recognition and simple explanation panels. See the spec for full
+details on the future roadmap.
+

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,9 @@
+PORT=4000
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/starpathvision
+S3_ENDPOINT=http://localhost:9000
+S3_BUCKET=starpathvision
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=minioadmin
+SMTP_HOST=localhost
+SMTP_USER=
+SMTP_PASS=

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "starpathvision-api",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "start": "node dist/main.js",
+    "build": "tsc -p tsconfig.json",
+    "start:dev": "ts-node-dev --respawn --transpile-only src/main.ts",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "multer": "^1.4.5",
+    "ioredis": "^5.4.1",
+    "bullmq": "^5.8.1",
+    "pg": "^8.11.3",
+    "nodemailer": "^6.9.13",
+    "pdf-lib": "^1.17.1",
+    "sharp": "^0.33.2",
+    "dotenv": "^16.4.5",
+    "minio": "^8.0.1"
+  },
+  "devDependencies": {
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.4.5",
+    "@types/node": "^20.11.30"
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,0 +1,36 @@
+import { Module } from '@nestjs/common';
+import { ClientsController } from './modules/clients/clients.controller';
+import { ClientsService } from './modules/clients/clients.service';
+import { SessionsController } from './modules/sessions/sessions.controller';
+import { SessionsService } from './modules/sessions/sessions.service';
+import { UploadsController } from './modules/uploads/uploads.controller';
+import { UploadsService } from './modules/uploads/uploads.service';
+import { VisionController } from './modules/vision/vision.controller';
+import { VisionService } from './modules/vision/vision.service';
+import { ReadingsController } from './modules/readings/readings.controller';
+import { ReadingsService } from './modules/readings/readings.service';
+import { StorageService } from './modules/storage/storage.service';
+import { EmailService } from './modules/email/email.service';
+import { PdfService } from './modules/pdf/pdf.service';
+
+@Module({
+  controllers: [
+    ClientsController,
+    SessionsController,
+    UploadsController,
+    VisionController,
+    ReadingsController,
+  ],
+  providers: [
+    ClientsService,
+    SessionsService,
+    UploadsService,
+    VisionService,
+    ReadingsService,
+    StorageService,
+    EmailService,
+    PdfService,
+  ],
+})
+export class AppModule {}
+

--- a/backend/src/common/config.ts
+++ b/backend/src/common/config.ts
@@ -1,0 +1,17 @@
+export const cfg = {
+  s3: {
+    endpoint: process.env.S3_ENDPOINT!,
+    bucket: process.env.S3_BUCKET!,
+    accessKey: process.env.S3_ACCESS_KEY!,
+    secretKey: process.env.S3_SECRET_KEY!,
+  },
+  db: {
+    url: process.env.DATABASE_URL!,
+  },
+  smtp: {
+    host: process.env.SMTP_HOST!,
+    user: process.env.SMTP_USER!,
+    pass: process.env.SMTP_PASS!,
+  },
+};
+

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,18 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import * as dotenv from 'dotenv';
+import { json, urlencoded } from 'express';
+
+dotenv.config();
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule, { cors: true });
+  app.use(json({ limit: '25mb' }));
+  app.use(urlencoded({ extended: true }));
+  app.setGlobalPrefix('v1');
+  const port = process.env.PORT || 4000;
+  await app.listen(port);
+  // eslint-disable-next-line no-console
+  console.log(`API running on http://localhost:${port}/v1`);
+}
+bootstrap();

--- a/backend/src/modules/clients/clients.controller.ts
+++ b/backend/src/modules/clients/clients.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { ClientsService } from './clients.service';
+
+@Controller('clients')
+export class ClientsController {
+  constructor(private readonly svc: ClientsService) {}
+
+  @Post()
+  async create(@Body() dto: any) {
+    return this.svc.create(dto);
+  }
+
+  @Get(':id')
+  async get(@Param('id') id: string) {
+    return this.svc.get(id);
+  }
+}
+

--- a/backend/src/modules/clients/clients.service.ts
+++ b/backend/src/modules/clients/clients.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+
+@Injectable()
+export class ClientsService {
+  async create(dto: any) {
+    // TODO: insert into DB
+    return { id: randomUUID(), ...dto };
+  }
+
+  async get(id: string) {
+    // TODO: fetch from DB
+    return { id, first_name: 'Demo', last_name: 'Klant' };
+  }
+}
+

--- a/backend/src/modules/email/email.service.ts
+++ b/backend/src/modules/email/email.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class EmailService {
+  // Placeholder for future implementation
+  async send(to: string, subject: string, body: string) {
+    // TODO: implement with nodemailer
+    return { to, subject };
+  }
+}
+

--- a/backend/src/modules/pdf/pdf.service.ts
+++ b/backend/src/modules/pdf/pdf.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class PdfService {
+  // Placeholder for future implementation
+  async create(readingId: string) {
+    // TODO: generate PDF using pdf-lib
+    return { readingId };
+  }
+}
+

--- a/backend/src/modules/readings/readings.controller.ts
+++ b/backend/src/modules/readings/readings.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ReadingsService } from './readings.service';
+
+@Controller('readings')
+export class ReadingsController {
+  constructor(private readonly svc: ReadingsService) {}
+
+  @Get(':id')
+  async get(@Param('id') id: string) {
+    return this.svc.get(id);
+  }
+}
+

--- a/backend/src/modules/readings/readings.service.ts
+++ b/backend/src/modules/readings/readings.service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ReadingsService {
+  async get(id: string) {
+    // TODO: fetch from DB
+    return { id, summary: 'Demo reading', full_text: 'Volledige tekst (demo)' };
+  }
+}
+

--- a/backend/src/modules/sessions/sessions.controller.ts
+++ b/backend/src/modules/sessions/sessions.controller.ts
@@ -1,0 +1,8 @@
+import { Controller } from '@nestjs/common';
+import { SessionsService } from './sessions.service';
+
+@Controller('sessions')
+export class SessionsController {
+  constructor(private readonly svc: SessionsService) {}
+}
+

--- a/backend/src/modules/sessions/sessions.service.ts
+++ b/backend/src/modules/sessions/sessions.service.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class SessionsService {}
+

--- a/backend/src/modules/storage/storage.service.ts
+++ b/backend/src/modules/storage/storage.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { Client as MinioClient } from 'minio';
+import { cfg } from '../../common/config';
+
+@Injectable()
+export class StorageService {
+  private m: MinioClient;
+  constructor() {
+    this.m = new MinioClient({
+      endPoint: new URL(cfg.s3.endpoint).hostname,
+      port: Number(new URL(cfg.s3.endpoint).port || 9000),
+      useSSL: cfg.s3.endpoint.startsWith('https'),
+      accessKey: cfg.s3.accessKey,
+      secretKey: cfg.s3.secretKey,
+    });
+  }
+
+  async presignPut(key: string, mime: string): Promise<string> {
+    return await this.m.presignedPutObject(cfg.s3.bucket, key, 60 * 10, {
+      'Content-Type': mime,
+    });
+  }
+}
+

--- a/backend/src/modules/uploads/uploads.controller.ts
+++ b/backend/src/modules/uploads/uploads.controller.ts
@@ -1,0 +1,22 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { UploadsService } from './uploads.service';
+
+@Controller('uploads')
+export class UploadsController {
+  constructor(private readonly svc: UploadsService) {}
+
+  @Post('presign')
+  async presign(
+    @Body()
+    dto: {
+      kind: 'image' | 'audio' | 'pdf';
+      mime: string;
+      bytes: number;
+      sessionId?: string;
+      clientId?: string;
+    },
+  ) {
+    return this.svc.presign(dto);
+  }
+}
+

--- a/backend/src/modules/uploads/uploads.service.ts
+++ b/backend/src/modules/uploads/uploads.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { StorageService } from '../storage/storage.service';
+
+@Injectable()
+export class UploadsService {
+  constructor(private storage: StorageService) {}
+
+  async presign(dto: {
+    kind: 'image' | 'audio' | 'pdf';
+    mime: string;
+    bytes: number;
+    sessionId?: string;
+    clientId?: string;
+  }) {
+    const key = `uploads/${dto.clientId ?? 'anon'}/${randomUUID()}`;
+    const url = await this.storage.presignPut(key, dto.mime);
+    // TODO: insert uploads row in DB
+    return { uploadId: randomUUID(), url, key };
+  }
+}
+

--- a/backend/src/modules/vision/vision.controller.ts
+++ b/backend/src/modules/vision/vision.controller.ts
@@ -1,0 +1,13 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { VisionService } from './vision.service';
+
+@Controller('vision')
+export class VisionController {
+  constructor(private readonly svc: VisionService) {}
+
+  @Post('tarot/recognize')
+  async recognizeTarot(@Body() dto: { uploadId: string; deckHint?: string }) {
+    return this.svc.recognizeTarot(dto);
+  }
+}
+

--- a/backend/src/modules/vision/vision.service.ts
+++ b/backend/src/modules/vision/vision.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class VisionService {
+  async recognizeTarot(dto: { uploadId: string; deckHint?: string }) {
+    // Stub response to unblock frontend
+    return {
+      readingId: 'demo-reading-id',
+      cards: [
+        { name: 'Kelken 3', orientation: 'upright', confidence: 0.92 },
+        { name: 'Zwaarden 9', orientation: 'upright', confidence: 0.71 },
+      ],
+      explanation: {
+        summary: 'Viering na zorgen; verlichting van stress.',
+        full: 'Uitleg (demo) met voorbeelden en vervolgstappen.',
+        model: 'demo-model',
+      },
+    };
+  }
+}
+

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2021",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "baseUrl": ".",
+    "paths": {
+      "*": ["src/*"]
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: starpathvision
+    ports: ["5432:5432"]
+    volumes: [dbdata:/var/lib/postgresql/data]
+
+  redis:
+    image: redis:7-alpine
+    ports: ["6379:6379"]
+
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports: ["9000:9000", "9001:9001"]
+    volumes: [miniodata:/data]
+
+  mailhog:
+    image: mailhog/mailhog
+    ports: ["1025:1025", "8025:8025"]
+
+volumes:
+  dbdata:
+  miniodata:
+

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_API_BASE=http://localhost:4000/v1
+

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "starpathvision-web",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.2.4",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@supabase/supabase-js": "^2.45.0",
+    "zod": "^3.23.8",
+    "react-hook-form": "^7.52.0",
+    "@hookform/resolvers": "^3.9.0",
+    "lucide-react": "^0.446.0",
+    "tailwindcss": "^3.4.4",
+    "@tailwindcss/forms": "^0.5.7"
+  }
+}
+

--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,0 +1,2 @@
+export default { plugins: { tailwindcss: {}, autoprefixer: {} } };
+

--- a/frontend/src/components/RecognitionOverlay.tsx
+++ b/frontend/src/components/RecognitionOverlay.tsx
@@ -1,0 +1,21 @@
+export default function RecognitionOverlay({ result }: { result: any }) {
+  if (!result) return null;
+  return (
+    <div className="card p-6 mt-4">
+      <h3 className="text-xl font-semibold mb-2">Gedetecteerde kaarten</h3>
+      <ul className="space-y-2">
+        {result.cards?.map((c: any, i: number) => (
+          <li key={i} className="flex items-center justify-between">
+            <span>
+              {c.name} {c.orientation ? `(${c.orientation})` : ''}
+            </span>
+            <span className="text-sm opacity-70">
+              {(c.confidence * 100).toFixed(1)}%
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/frontend/src/components/UploadArea.tsx
+++ b/frontend/src/components/UploadArea.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import { api } from '@/lib/api';
+
+export default function UploadArea({
+  sessionId,
+  clientId,
+  onPresigned,
+}: {
+  sessionId?: string;
+  clientId?: string;
+  onPresigned: (url: string, key: string) => void;
+}) {
+  const [drag, setDrag] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  async function handleFiles(files: FileList | null) {
+    if (!files || files.length === 0) return;
+    setLoading(true);
+    const f = files[0];
+    const presign = await api<{ uploadId: string; url: string; key: string }>(
+      '/uploads/presign',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          kind: 'image',
+          mime: f.type,
+          bytes: f.size,
+          sessionId,
+          clientId,
+        }),
+      },
+    );
+    await fetch(presign.url, {
+      method: 'PUT',
+      body: f,
+      headers: { 'Content-Type': f.type },
+    });
+    setLoading(false);
+    onPresigned(presign.url, presign.key);
+  }
+
+  return (
+    <div
+      className={`card p-6 border-dashed ${drag ? 'border-indigo-400' : 'border-white/10'}`}
+      onDragOver={(e) => {
+        e.preventDefault();
+        setDrag(true);
+      }}
+      onDragLeave={() => setDrag(false)}
+      onDrop={(e) => {
+        e.preventDefault();
+        setDrag(false);
+        handleFiles(e.dataTransfer.files);
+      }}
+    >
+      <div className="text-center space-y-3">
+        <p className="text-lg">Drag & drop je foto hier</p>
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => handleFiles(e.target.files)}
+        />
+        {loading && <p>Uploaden…</p>}
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/WhyPanel.tsx
+++ b/frontend/src/components/WhyPanel.tsx
@@ -1,0 +1,15 @@
+export default function WhyPanel({
+  explanation,
+}: {
+  explanation?: { summary: string; full: string };
+}) {
+  if (!explanation) return null;
+  return (
+    <div className="card p-6 mt-4">
+      <h3 className="text-xl font-semibold mb-2">Waarom – Uitleg</h3>
+      <p className="font-medium mb-2">{explanation.summary}</p>
+      <p className="opacity-90 whitespace-pre-wrap">{explanation.full}</p>
+    </div>
+  );
+}
+

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,12 @@
+export const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:4000/v1';
+
+export async function api<T>(path: string, opts: RequestInit = {}): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    headers: { 'Content-Type': 'application/json', ...(opts.headers || {}) },
+    ...opts,
+  });
+  if (!res.ok) throw new Error(`API ${path} failed: ${res.status}`);
+  return res.json();
+}
+

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,0 +1,7 @@
+import '@/styles/globals.css';
+import type { AppProps } from 'next/app';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import UploadArea from '@/components/UploadArea';
+import RecognitionOverlay from '@/components/RecognitionOverlay';
+import WhyPanel from '@/components/WhyPanel';
+import { api } from '@/lib/api';
+
+export default function Home() {
+  const [result, setResult] = useState<any>(null);
+
+  async function onUploaded(_url: string, _key: string) {
+    const r = await api('/vision/tarot/recognize', {
+      method: 'POST',
+      body: JSON.stringify({ uploadId: 'demo' }),
+    });
+    setResult(r);
+  }
+
+  return (
+    <main className="max-w-3xl mx-auto p-6 space-y-4">
+      <h1 className="text-3xl font-bold">StarpathVision</h1>
+      <p className="opacity-90">
+        Upload een foto van je kaarten en laat de AI het werk doen.
+      </p>
+      <UploadArea onPresigned={onUploaded} />
+      <RecognitionOverlay result={result} />
+      <WhyPanel explanation={result?.explanation} />
+    </main>
+  );
+}
+

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,12 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, #__next { height: 100%; }
+body {
+  @apply bg-gradient-to-b from-slate-950 via-indigo-950 to-black text-slate-100;
+}
+.card {
+  @apply bg-white/5 backdrop-blur rounded-2xl shadow-xl border border-white/10;
+}
+

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  content: [
+    './src/pages/**/*.{js,ts,jsx,tsx}',
+    './src/components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: { extend: {} },
+  plugins: [require('@tailwindcss/forms')],
+};
+


### PR DESCRIPTION
## Summary
- add docker compose for postgres, redis, minio and mailhog
- scaffold NestJS backend with upload presign endpoint and tarot recognition stub
- scaffold Next.js frontend with image upload and result panels

## Testing
- `npm install` (backend) *(fails: 403 Forbidden from registry)*
- `npm run build` (backend) *(fails: missing modules because dependencies not installed)*
- `npm install` (frontend) *(fails: 403 Forbidden from registry)*
- `npm run build` (frontend) *(fails: next not found because dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68983a3d9f588329931a1f9582dad2ed