### PR TITLE
feat: add pdf generation and email service

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { ReadingsService } from './modules/readings/readings.service';
 import { StorageService } from './modules/storage/storage.service';
 import { EmailService } from './modules/email/email.service';
 import { PdfService } from './modules/pdf/pdf.service';
+import { EmailController } from './modules/email/email.controller';
 
 @Module({
   controllers: [
@@ -20,6 +21,7 @@ import { PdfService } from './modules/pdf/pdf.service';
     UploadsController,
     VisionController,
     ReadingsController,
+    EmailController,
   ],
   providers: [
     ClientsService,

--- a/backend/src/modules/email/email.controller.ts
+++ b/backend/src/modules/email/email.controller.ts
@@ -1,0 +1,23 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { EmailService } from './email.service';
+
+@Controller('email')
+export class EmailController {
+  constructor(private readonly svc: EmailService) {}
+
+  @Post('send')
+  async send(
+    @Body()
+    dto: {
+      to: string;
+      subject: string;
+      body: string;
+      link?: string;
+      pdfBase64?: string;
+    },
+  ) {
+    const pdf = dto.pdfBase64 ? Buffer.from(dto.pdfBase64, 'base64') : undefined;
+    await this.svc.send(dto.to, dto.subject, dto.body, { link: dto.link, pdf });
+    return { sent: true };
+  }
+}

--- a/backend/src/modules/email/email.service.ts
+++ b/backend/src/modules/email/email.service.ts
@@ -1,10 +1,37 @@
 import { Injectable } from '@nestjs/common';
+import * as nodemailer from 'nodemailer';
+import { cfg } from '../../common/config';
 
 @Injectable()
 export class EmailService {
-  // Placeholder for future implementation
-  async send(to: string, subject: string, body: string) {
-    // TODO: implement with nodemailer
+  private transporter = nodemailer.createTransport({
+    host: cfg.smtp.host,
+    port: 587,
+    secure: false,
+    auth: { user: cfg.smtp.user, pass: cfg.smtp.pass },
+  });
+
+  /**
+   * Send an email. Optionally provide a PDF buffer to attach or a link that
+   * will be appended to the body.
+   */
+  async send(
+    to: string,
+    subject: string,
+    body: string,
+    opts?: { pdf?: Buffer; link?: string },
+  ) {
+    const mail = {
+      from: cfg.smtp.user,
+      to,
+      subject,
+      text: opts?.link ? `${body}\n${opts.link}` : body,
+      attachments: opts?.pdf
+        ? [{ filename: 'reading.pdf', content: opts.pdf }]
+        : undefined,
+    };
+
+    await this.transporter.sendMail(mail);
     return { to, subject };
   }
 }

--- a/backend/src/modules/pdf/pdf.service.ts
+++ b/backend/src/modules/pdf/pdf.service.ts
@@ -1,11 +1,67 @@
 import { Injectable } from '@nestjs/common';
+import { PDFDocument, StandardFonts } from 'pdf-lib';
+import { ReadingsService } from '../readings/readings.service';
+
+// 1x1 transparent PNG used as a fallback logo/card image
+const PLACEHOLDER_IMG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9W410wAAAABJRU5ErkJggg==',
+  'base64',
+);
 
 @Injectable()
 export class PdfService {
-  // Placeholder for future implementation
-  async create(readingId: string) {
-    // TODO: generate PDF using pdf-lib
-    return { readingId };
+  constructor(private readonly readingsSvc: ReadingsService) {}
+
+  /**
+   * Compose an A4 PDF for the given reading containing a logo, the reading
+   * text and thumbnails of the cards used in the reading. Returns the PDF as a
+   * Buffer.
+   */
+  async create(readingId: string): Promise<Buffer> {
+    const reading = await this.readingsSvc.get(readingId);
+
+    const pdfDoc = await PDFDocument.create();
+    // Dimensions for an A4 page in PDF points
+    const page = pdfDoc.addPage([595.28, 841.89]);
+    const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+    const { width, height } = page.getSize();
+
+    // Draw logo at the top left
+    try {
+      const logoImg = await pdfDoc.embedPng(PLACEHOLDER_IMG);
+      page.drawImage(logoImg, { x: 40, y: height - 90, width: 100, height: 50 });
+    } catch {
+      // ignore logo failures
+    }
+
+    // Compose reading text
+    const text = `${reading.summary}\n\n${reading.full_text ?? ''}`;
+    const lines = text.split(/\n/);
+    let y = height - 130;
+    for (const line of lines) {
+      page.drawText(line, { x: 40, y, size: 12, font });
+      y -= 14;
+    }
+
+    // Card thumbnails (if available)
+    const cards: any[] = (reading as any).cards || [];
+    if (cards.length) {
+      y -= 170; // leave some space after text
+      let x = 40;
+      for (const c of cards) {
+        try {
+          const imgBytes = c.thumbnail || PLACEHOLDER_IMG;
+          const img = await pdfDoc.embedPng(imgBytes);
+          page.drawImage(img, { x, y, width: 100, height: 150 });
+        } catch {
+          // ignore image failures
+        }
+        x += 110;
+      }
+    }
+
+    const pdfBytes = await pdfDoc.save();
+    return Buffer.from(pdfBytes);
   }
 }
 

--- a/backend/src/modules/readings/readings.controller.ts
+++ b/backend/src/modules/readings/readings.controller.ts
@@ -1,13 +1,28 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, Post, Res } from '@nestjs/common';
+import { Response } from 'express';
 import { ReadingsService } from './readings.service';
+import { PdfService } from '../pdf/pdf.service';
 
 @Controller('readings')
 export class ReadingsController {
-  constructor(private readonly svc: ReadingsService) {}
+  constructor(
+    private readonly svc: ReadingsService,
+    private readonly pdfSvc: PdfService,
+  ) {}
 
   @Get(':id')
   async get(@Param('id') id: string) {
     return this.svc.get(id);
+  }
+
+  @Post(':id/pdf')
+  async pdf(@Param('id') id: string, @Res() res: Response) {
+    const pdf = await this.pdfSvc.create(id);
+    res.set({
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename=reading-${id}.pdf`,
+    });
+    res.send(pdf);
   }
 }
 


### PR DESCRIPTION
## Summary
- generate reading PDFs with logo, text, and card thumbnails using pdf-lib
- configure Nodemailer and expose email sending endpoint
- provide POST /readings/:id/pdf endpoint for PDF download

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find configuration file)


------
https://chatgpt.com/codex/tasks/task_e_68983dc643b0832991db07f48cfee612