### PR TITLE
feat: add client and session forms with timeline

### DIFF
--- a/frontend/src/components/ClientRegistration.tsx
+++ b/frontend/src/components/ClientRegistration.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { api } from '@/lib/api';
+
+const schema = z.object({
+  first_name: z.string().min(1, 'Voornaam is verplicht'),
+  last_name: z.string().min(1, 'Achternaam is verplicht'),
+  email: z.string().email('Ongeldig e-mailadres'),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function ClientRegistration() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({ resolver: zodResolver(schema) });
+  const [result, setResult] = useState<any>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(data: FormData) {
+    try {
+      const res = await api('/clients', {
+        method: 'POST',
+        body: JSON.stringify(data),
+      });
+      setResult(res);
+      setError(null);
+    } catch (e: any) {
+      setError(e.message);
+    }
+  }
+
+  return (
+    <div className="card p-6">
+      <h2 className="text-xl font-semibold mb-4">Registreer Cliënt</h2>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <div>
+          <label className="block mb-1">Voornaam</label>
+          <input
+            {...register('first_name')}
+            className="w-full border rounded p-2 bg-transparent"
+          />
+          {errors.first_name && (
+            <p className="text-red-500 text-sm">{errors.first_name.message}</p>
+          )}
+        </div>
+        <div>
+          <label className="block mb-1">Achternaam</label>
+          <input
+            {...register('last_name')}
+            className="w-full border rounded p-2 bg-transparent"
+          />
+          {errors.last_name && (
+            <p className="text-red-500 text-sm">{errors.last_name.message}</p>
+          )}
+        </div>
+        <div>
+          <label className="block mb-1">Email</label>
+          <input
+            type="email"
+            {...register('email')}
+            className="w-full border rounded p-2 bg-transparent"
+          />
+          {errors.email && (
+            <p className="text-red-500 text-sm">{errors.email.message}</p>
+          )}
+        </div>
+        <button
+          type="submit"
+          className="bg-indigo-600 text-white px-4 py-2 rounded"
+        >
+          Opslaan
+        </button>
+      </form>
+      {result && (
+        <p className="mt-4 text-green-600">
+          Cliënt aangemaakt met ID: {result.id}
+        </p>
+      )}
+      {error && <p className="mt-4 text-red-600">{error}</p>}
+    </div>
+  );
+}
+

--- a/frontend/src/components/SessionCreate.tsx
+++ b/frontend/src/components/SessionCreate.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { api } from '@/lib/api';
+
+const schema = z.object({
+  clientId: z.string().min(1, 'Client ID is verplicht'),
+  date: z.string().min(1, 'Datum is verplicht'),
+  notes: z.string().optional(),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function SessionCreate() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({ resolver: zodResolver(schema) });
+  const [result, setResult] = useState<any>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(data: FormData) {
+    try {
+      const res = await api('/sessions', {
+        method: 'POST',
+        body: JSON.stringify(data),
+      });
+      setResult(res);
+      setError(null);
+    } catch (e: any) {
+      setError(e.message);
+    }
+  }
+
+  return (
+    <div className="card p-6">
+      <h2 className="text-xl font-semibold mb-4">Nieuwe Sessie</h2>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <div>
+          <label className="block mb-1">Client ID</label>
+          <input
+            {...register('clientId')}
+            className="w-full border rounded p-2 bg-transparent"
+          />
+          {errors.clientId && (
+            <p className="text-red-500 text-sm">{errors.clientId.message}</p>
+          )}
+        </div>
+        <div>
+          <label className="block mb-1">Datum</label>
+          <input
+            type="date"
+            {...register('date')}
+            className="w-full border rounded p-2 bg-transparent"
+          />
+          {errors.date && (
+            <p className="text-red-500 text-sm">{errors.date.message}</p>
+          )}
+        </div>
+        <div>
+          <label className="block mb-1">Notities</label>
+          <textarea
+            {...register('notes')}
+            className="w-full border rounded p-2 bg-transparent"
+          />
+        </div>
+        <button
+          type="submit"
+          className="bg-indigo-600 text-white px-4 py-2 rounded"
+        >
+          Aanmaken
+        </button>
+      </form>
+      {result && (
+        <p className="mt-4 text-green-600">Sessie aangemaakt met ID: {result.id}</p>
+      )}
+      {error && <p className="mt-4 text-red-600">{error}</p>}
+    </div>
+  );
+}
+

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -1,0 +1,35 @@
+export type TimelineSession = {
+  id: string;
+  date: string;
+  summary?: string;
+  comparison?: string;
+};
+
+export default function Timeline({
+  sessions,
+}: {
+  sessions: TimelineSession[];
+}) {
+  if (!sessions || sessions.length === 0) {
+    return <p>Geen sessies beschikbaar.</p>;
+  }
+  return (
+    <ul className="space-y-6">
+      {sessions.map((s) => (
+        <li key={s.id} className="relative pl-6">
+          <div className="absolute left-0 top-2 w-3 h-3 rounded-full bg-indigo-500" />
+          <div className="card p-4">
+            <p className="font-semibold">
+              {new Date(s.date).toLocaleDateString()}
+            </p>
+            {s.summary && <p className="mt-1">{s.summary}</p>}
+            {s.comparison && (
+              <p className="mt-2 text-sm opacity-80">{s.comparison}</p>
+            )}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+

--- a/frontend/src/pages/clients/index.tsx
+++ b/frontend/src/pages/clients/index.tsx
@@ -1,0 +1,11 @@
+import ClientRegistration from '@/components/ClientRegistration';
+
+export default function ClientRegistrationPage() {
+  return (
+    <main className="max-w-3xl mx-auto p-6 space-y-4">
+      <h1 className="text-3xl font-bold">Cliënt Registratie</h1>
+      <ClientRegistration />
+    </main>
+  );
+}
+

--- a/frontend/src/pages/sessions/create.tsx
+++ b/frontend/src/pages/sessions/create.tsx
@@ -1,0 +1,11 @@
+import SessionCreate from '@/components/SessionCreate';
+
+export default function SessionCreatePage() {
+  return (
+    <main className="max-w-3xl mx-auto p-6 space-y-4">
+      <h1 className="text-3xl font-bold">Nieuwe Sessie</h1>
+      <SessionCreate />
+    </main>
+  );
+}
+

--- a/frontend/src/pages/sessions/index.tsx
+++ b/frontend/src/pages/sessions/index.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import Timeline, { TimelineSession } from '@/components/Timeline';
+import { api } from '@/lib/api';
+
+export default function SessionsPage() {
+  const [sessions, setSessions] = useState<TimelineSession[]>([]);
+  useEffect(() => {
+    api<TimelineSession[]>('/sessions')
+      .then(setSessions)
+      .catch(() => setSessions([]));
+  }, []);
+
+  return (
+    <main className="max-w-3xl mx-auto p-6 space-y-4">
+      <h1 className="text-3xl font-bold">Sessies</h1>
+      <Timeline sessions={sessions} />
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add client registration form with zod validation
- implement session creation form and timeline view
- wire new components into clients and sessions pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to install required TypeScript dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68983ddc6cf083299c394bacfb384fbf