### PR TITLE
feat: add jwt auth with role-based guards

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -12,8 +12,12 @@ import { ReadingsService } from './modules/readings/readings.service';
 import { StorageService } from './modules/storage/storage.service';
 import { EmailService } from './modules/email/email.service';
 import { PdfService } from './modules/pdf/pdf.service';
+import { AuthModule } from './modules/auth/auth.module';
+import { AuthGuard } from './common/guards/auth.guard';
+import { RolesGuard } from './common/guards/roles.guard';
 
 @Module({
+  imports: [AuthModule],
   controllers: [
     ClientsController,
     SessionsController,
@@ -30,6 +34,8 @@ import { PdfService } from './modules/pdf/pdf.service';
     StorageService,
     EmailService,
     PdfService,
+    AuthGuard,
+    RolesGuard,
   ],
 })
 export class AppModule {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { ReadingsService } from './modules/readings/readings.service';
 import { StorageService } from './modules/storage/storage.service';
 import { EmailService } from './modules/email/email.service';
 import { PdfService } from './modules/pdf/pdf.service';
+import { EmailController } from './modules/email/email.controller';
 import { AuthModule } from './modules/auth/auth.module';
 import { AuthGuard } from './common/guards/auth.guard';
 import { RolesGuard } from './common/guards/roles.guard';
@@ -24,6 +25,7 @@ import { RolesGuard } from './common/guards/roles.guard';
     UploadsController,
     VisionController,
     ReadingsController,
+    EmailController,
   ],
   providers: [
     ClientsService,

--- a/backend/src/common/config.ts
+++ b/backend/src/common/config.ts
@@ -13,5 +13,10 @@ export const cfg = {
     user: process.env.SMTP_USER!,
     pass: process.env.SMTP_PASS!,
   },
+  auth: {
+    jwtSecret: process.env.JWT_SECRET!,
+    ownerPassword: process.env.OWNER_PASSWORD!,
+    assistantPassword: process.env.ASSISTANT_PASSWORD!,
+  },
 };
 

--- a/backend/src/common/guards/auth.guard.ts
+++ b/backend/src/common/guards/auth.guard.ts
@@ -1,0 +1,24 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { Request } from 'express';
+import { AuthService } from '../../modules/auth/auth.service';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  constructor(private readonly auth: AuthService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest<Request>();
+    const header = req.headers['authorization'];
+    if (!header || !header.startsWith('Bearer ')) {
+      throw new UnauthorizedException();
+    }
+    const token = header.slice(7);
+    try {
+      const payload = this.auth.verify(token);
+      (req as any).user = payload;
+      return true;
+    } catch {
+      throw new UnauthorizedException();
+    }
+  }
+}

--- a/backend/src/common/guards/roles.guard.ts
+++ b/backend/src/common/guards/roles.guard.ts
@@ -1,0 +1,23 @@
+import { CanActivate, ExecutionContext, Injectable, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Role } from '../roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const roles =
+      this.reflector.get<Role[]>('roles', context.getHandler()) ||
+      this.reflector.get<Role[]>('roles', context.getClass());
+    if (!roles || roles.length === 0) {
+      return true;
+    }
+    const req = context.switchToHttp().getRequest();
+    const user = (req as any).user as { role: Role } | undefined;
+    if (user && roles.includes(user.role)) {
+      return true;
+    }
+    throw new ForbiddenException();
+  }
+}

--- a/backend/src/common/roles.decorator.ts
+++ b/backend/src/common/roles.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export type Role = 'owner' | 'assistant';
+export const Roles = (...roles: Role[]) => SetMetadata('roles', roles);

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -1,0 +1,19 @@
+import { Body, Controller, Post, UnauthorizedException } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { cfg } from '../../common/config';
+import { Role } from '../../common/roles.decorator';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly svc: AuthService) {}
+
+  @Post('token')
+  async token(@Body() dto: { role: Role; password: string }) {
+    const expected =
+      dto.role === 'owner' ? cfg.auth.ownerPassword : cfg.auth.assistantPassword;
+    if (dto.password !== expected) {
+      throw new UnauthorizedException();
+    }
+    return { access_token: this.svc.issue(dto.role) };
+  }
+}

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+
+@Module({
+  providers: [AuthService],
+  controllers: [AuthController],
+  exports: [AuthService],
+})
+export class AuthModule {}

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import { createHmac } from 'crypto';
+import { cfg } from '../../common/config';
+import { Role } from '../../common/roles.decorator';
+
+function base64url(input: Buffer | string) {
+  return Buffer.from(input).toString('base64url');
+}
+
+@Injectable()
+export class AuthService {
+  private readonly secret = cfg.auth.jwtSecret;
+
+  issue(role: Role) {
+    const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+    const payload = base64url(
+      JSON.stringify({ role, exp: Math.floor(Date.now() / 1000) + 60 * 60 })
+    );
+    const data = `${header}.${payload}`;
+    const signature = createHmac('sha256', this.secret)
+      .update(data)
+      .digest('base64url');
+    return `${data}.${signature}`;
+  }
+
+  verify(token: string): { role: Role } {
+    const [h, p, s] = token.split('.');
+    if (!h || !p || !s) {
+      throw new Error('invalid token');
+    }
+    const data = `${h}.${p}`;
+    const expected = createHmac('sha256', this.secret)
+      .update(data)
+      .digest('base64url');
+    if (s !== expected) {
+      throw new Error('invalid signature');
+    }
+    const payload = JSON.parse(Buffer.from(p, 'base64url').toString());
+    if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {
+      throw new Error('token expired');
+    }
+    return { role: payload.role };
+  }
+}

--- a/backend/src/modules/clients/clients.controller.ts
+++ b/backend/src/modules/clients/clients.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { ClientsService } from './clients.service';
 import { AuthGuard } from '../../common/guards/auth.guard';
 import { RolesGuard } from '../../common/guards/roles.guard';
@@ -11,13 +20,20 @@ export class ClientsController {
   constructor(private readonly svc: ClientsService) {}
 
   @Post()
-  async create(@Body() dto: any) {
+  async create(@Body() dto: { first_name: string; last_name: string }) {
+    if (typeof dto.first_name !== 'string' || typeof dto.last_name !== 'string') {
+      throw new BadRequestException();
+    }
     return this.svc.create(dto);
   }
 
   @Get(':id')
   async get(@Param('id') id: string) {
-    return this.svc.get(id);
+    const client = await this.svc.get(id);
+    if (!client) {
+      throw new NotFoundException();
+    }
+    return client;
   }
 }
 

--- a/backend/src/modules/clients/clients.controller.ts
+++ b/backend/src/modules/clients/clients.controller.ts
@@ -1,6 +1,11 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
 import { ClientsService } from './clients.service';
+import { AuthGuard } from '../../common/guards/auth.guard';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { Roles } from '../../common/roles.decorator';
 
+@UseGuards(AuthGuard, RolesGuard)
+@Roles('owner')
 @Controller('clients')
 export class ClientsController {
   constructor(private readonly svc: ClientsService) {}

--- a/backend/src/modules/readings/readings.controller.ts
+++ b/backend/src/modules/readings/readings.controller.ts
@@ -1,6 +1,11 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
 import { ReadingsService } from './readings.service';
+import { AuthGuard } from '../../common/guards/auth.guard';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { Roles } from '../../common/roles.decorator';
 
+@UseGuards(AuthGuard, RolesGuard)
+@Roles('owner', 'assistant')
 @Controller('readings')
 export class ReadingsController {
   constructor(private readonly svc: ReadingsService) {}

--- a/backend/src/modules/readings/readings.controller.ts
+++ b/backend/src/modules/readings/readings.controller.ts
@@ -1,5 +1,7 @@
-import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Post, Res, UseGuards } from '@nestjs/common';
+import { Response } from 'express';
 import { ReadingsService } from './readings.service';
+import { PdfService } from '../pdf/pdf.service';
 import { AuthGuard } from '../../common/guards/auth.guard';
 import { RolesGuard } from '../../common/guards/roles.guard';
 import { Roles } from '../../common/roles.decorator';
@@ -8,11 +10,24 @@ import { Roles } from '../../common/roles.decorator';
 @Roles('owner', 'assistant')
 @Controller('readings')
 export class ReadingsController {
-  constructor(private readonly svc: ReadingsService) {}
+  constructor(
+    private readonly svc: ReadingsService,
+    private readonly pdfSvc: PdfService,
+  ) {}
 
   @Get(':id')
   async get(@Param('id') id: string) {
     return this.svc.get(id);
+  }
+
+  @Post(':id/pdf')
+  async pdf(@Param('id') id: string, @Res() res: Response) {
+    const pdf = await this.pdfSvc.create(id);
+    res.set({
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename=reading-${id}.pdf`,
+    });
+    res.send(pdf);
   }
 }
 

--- a/backend/src/modules/sessions/sessions.controller.ts
+++ b/backend/src/modules/sessions/sessions.controller.ts
@@ -1,6 +1,11 @@
-import { Controller } from '@nestjs/common';
+import { Controller, UseGuards } from '@nestjs/common';
 import { SessionsService } from './sessions.service';
+import { AuthGuard } from '../../common/guards/auth.guard';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { Roles } from '../../common/roles.decorator';
 
+@UseGuards(AuthGuard, RolesGuard)
+@Roles('owner')
 @Controller('sessions')
 export class SessionsController {
   constructor(private readonly svc: SessionsService) {}

--- a/backend/src/modules/sessions/sessions.controller.ts
+++ b/backend/src/modules/sessions/sessions.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
 import { SessionsService } from './sessions.service';
 import { AuthGuard } from '../../common/guards/auth.guard';
 import { RolesGuard } from '../../common/guards/roles.guard';
@@ -6,8 +6,23 @@ import { Roles } from '../../common/roles.decorator';
 
 @UseGuards(AuthGuard, RolesGuard)
 @Roles('owner')
-@Controller('sessions')
+@Controller()
 export class SessionsController {
   constructor(private readonly svc: SessionsService) {}
+
+  @Post('sessions')
+  async create(@Body() dto: any) {
+    return this.svc.create(dto);
+  }
+
+  @Get('sessions/:id')
+  async get(@Param('id') id: string) {
+    return this.svc.get(id);
+  }
+
+  @Get('clients/:clientId/sessions')
+  async list(@Param('clientId') clientId: string) {
+    return this.svc.list(clientId);
+  }
 }
 

--- a/backend/src/modules/uploads/uploads.controller.ts
+++ b/backend/src/modules/uploads/uploads.controller.ts
@@ -1,6 +1,11 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { UploadsService } from './uploads.service';
+import { AuthGuard } from '../../common/guards/auth.guard';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { Roles } from '../../common/roles.decorator';
 
+@UseGuards(AuthGuard, RolesGuard)
+@Roles('owner', 'assistant')
 @Controller('uploads')
 export class UploadsController {
   constructor(private readonly svc: UploadsService) {}


### PR DESCRIPTION
## Summary
- add auth module issuing and verifying JWTs for owner/assistant roles
- create AuthGuard and RolesGuard and apply to client, session, upload, and reading routes
- wire up AuthModule and register guards in app module

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Cannot find module '@nestjs/common', missing dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68983dd3012c83299626bf9edf9c109b