### PR TITLE
Record upload metadata and implement MinIO retrieval

### DIFF
--- a/backend/src/modules/storage/storage.service.ts
+++ b/backend/src/modules/storage/storage.service.ts
@@ -21,13 +21,15 @@ export class StorageService {
     });
   }
 
-  async get(key: string): Promise<Buffer> {
+  async getObjectBuffer(key: string): Promise<Buffer> {
     const stream = await this.m.getObject(cfg.s3.bucket, key);
     const chunks: Buffer[] = [];
     return new Promise<Buffer>((resolve, reject) => {
-      stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+      stream.on('data', (chunk) =>
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)),
+      );
       stream.on('end', () => resolve(Buffer.concat(chunks)));
-      stream.on('error', (err: Error) => reject(err));
+      stream.on('error', (err) => reject(err));
     });
   }
 }

--- a/backend/src/modules/storage/storage.service.ts
+++ b/backend/src/modules/storage/storage.service.ts
@@ -21,13 +21,13 @@ export class StorageService {
     });
   }
 
-  async getObjectBuffer(key: string): Promise<Buffer> {
+  async get(key: string): Promise<Buffer> {
     const stream = await this.m.getObject(cfg.s3.bucket, key);
-    return await new Promise<Buffer>((resolve, reject) => {
-      const chunks: Buffer[] = [];
-      stream.on('data', (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+    const chunks: Buffer[] = [];
+    return new Promise<Buffer>((resolve, reject) => {
+      stream.on('data', (chunk: Buffer) => chunks.push(chunk));
       stream.on('end', () => resolve(Buffer.concat(chunks)));
-      stream.on('error', (err) => reject(err));
+      stream.on('error', (err: Error) => reject(err));
     });
   }
 }

--- a/backend/src/modules/storage/storage.service.ts
+++ b/backend/src/modules/storage/storage.service.ts
@@ -20,5 +20,15 @@ export class StorageService {
       'Content-Type': mime,
     });
   }
+
+  async getObjectBuffer(key: string): Promise<Buffer> {
+    const stream = await this.m.getObject(cfg.s3.bucket, key);
+    return await new Promise<Buffer>((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      stream.on('data', (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+      stream.on('end', () => resolve(Buffer.concat(chunks)));
+      stream.on('error', (err) => reject(err));
+    });
+  }
 }
 

--- a/backend/src/modules/uploads/uploads.service.ts
+++ b/backend/src/modules/uploads/uploads.service.ts
@@ -1,10 +1,15 @@
 import { Injectable } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { StorageService } from '../storage/storage.service';
+import { Pool } from 'pg';
+import { cfg } from '../../common/config';
 
 @Injectable()
 export class UploadsService {
-  constructor(private storage: StorageService) {}
+  private db: Pool;
+  constructor(private storage: StorageService) {
+    this.db = new Pool({ connectionString: cfg.db.url });
+  }
 
   async presign(dto: {
     kind: 'image' | 'audio' | 'pdf';
@@ -15,8 +20,12 @@ export class UploadsService {
   }) {
     const key = `uploads/${dto.clientId ?? 'anon'}/${randomUUID()}`;
     const url = await this.storage.presignPut(key, dto.mime);
-    // TODO: insert uploads row in DB
-    return { uploadId: randomUUID(), url, key };
+    const result = await this.db.query(
+      `INSERT INTO uploads (storage_key, mime, bytes, session_id, client_id)
+       VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+      [key, dto.mime, dto.bytes, dto.sessionId ?? null, dto.clientId ?? null],
+    );
+    return { uploadId: result.rows[0].id, url, key };
   }
 }
 


### PR DESCRIPTION
## Summary
- persist upload records in database instead of UUID placeholders
- add storage service helper to fetch uploaded objects as buffers

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find config)


------
https://chatgpt.com/codex/tasks/task_e_68983d9ba120832981363d486d01a7fc