### PR TITLE
Add session service and controller routes

### DIFF
--- a/backend/src/modules/sessions/sessions.controller.ts
+++ b/backend/src/modules/sessions/sessions.controller.ts
@@ -1,8 +1,23 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { SessionsService } from './sessions.service';
 
-@Controller('sessions')
+@Controller()
 export class SessionsController {
   constructor(private readonly svc: SessionsService) {}
+
+  @Post('sessions')
+  async create(@Body() dto: any) {
+    return this.svc.create(dto);
+  }
+
+  @Get('sessions/:id')
+  async get(@Param('id') id: string) {
+    return this.svc.get(id);
+  }
+
+  @Get('clients/:clientId/sessions')
+  async list(@Param('clientId') clientId: string) {
+    return this.svc.list(clientId);
+  }
 }
 

--- a/backend/src/modules/sessions/sessions.service.ts
+++ b/backend/src/modules/sessions/sessions.service.ts
@@ -1,5 +1,53 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Pool } from 'pg';
+import { randomUUID } from 'crypto';
+import { cfg } from '../../common/config';
+
+interface Session {
+  id: string;
+  client_id: string;
+  created_at: Date;
+}
 
 @Injectable()
-export class SessionsService {}
+export class SessionsService {
+  private db: Pool;
+
+  constructor() {
+    this.db = new Pool({ connectionString: cfg.db.url });
+  }
+
+  async create(dto: { client_id: string }): Promise<Session> {
+    // Ensure the client exists to satisfy FK constraints
+    const client = await this.db.query('SELECT id FROM clients WHERE id = $1', [
+      dto.client_id,
+    ]);
+    if (client.rowCount === 0) {
+      throw new NotFoundException('Client not found');
+    }
+
+    const id = randomUUID();
+    const { rows } = await this.db.query(
+      'INSERT INTO sessions (id, client_id, created_at) VALUES ($1, $2, NOW()) RETURNING *',
+      [id, dto.client_id],
+    );
+    return rows[0];
+  }
+
+  async get(id: string): Promise<Session | undefined> {
+    const { rows } = await this.db.query(
+      'SELECT id, client_id, created_at FROM sessions WHERE id = $1',
+      [id],
+    );
+    return rows[0];
+  }
+
+  async list(clientId: string): Promise<Session[]> {
+    const { rows } = await this.db.query(
+      'SELECT id, client_id, created_at FROM sessions WHERE client_id = $1 ORDER BY created_at DESC',
+      [clientId],
+    );
+    return rows;
+  }
+}
 


### PR DESCRIPTION
## Summary
- implement SessionsService with database-backed create, get, list operations
- add session controller routes for creating sessions and fetching by id or client

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: Cannot find module '@nestjs/common' and other dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_68983d9520ac8329b275294b7b9bc341