### PR TITLE
chore: add linting, testing, and ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install backend dependencies
+        run: |
+          cd backend
+          npm install
+      - name: Install frontend dependencies
+        run: |
+          cd frontend
+          npm install
+      - name: Lint backend
+        run: |
+          cd backend
+          npm run lint
+      - name: Lint frontend
+        run: |
+          cd frontend
+          npm run lint
+      - name: Test backend
+        run: |
+          cd backend
+          npm test
+      - name: Test frontend
+        run: |
+          cd frontend
+          npm test

--- a/backend/eslint.config.cjs
+++ b/backend/eslint.config.cjs
@@ -1,0 +1,19 @@
+const js = require('@eslint/js');
+const tsPlugin = require('@typescript-eslint/eslint-plugin');
+const tsParser = require('@typescript-eslint/parser');
+
+module.exports = [
+  js.configs.recommended,
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+    },
+  },
+];

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/*.spec.ts'],
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,9 @@
     "start": "node dist/main.js",
     "build": "tsc -p tsconfig.json",
     "start:dev": "ts-node-dev --respawn --transpile-only src/main.ts",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "jest",
+    "migrate": "bash -c 'for f in migrations/*.sql; do echo Running $f; psql \"$DATABASE_URL\" -v ON_ERROR_STOP=1 -f \"$f\"; done'"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
@@ -25,6 +27,12 @@
   "devDependencies": {
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.4.5",
-    "@types/node": "^20.11.30"
+    "@types/node": "^20.11.30",
+    "eslint": "^8.57.0",
+    "@typescript-eslint/parser": "^7.7.0",
+    "@typescript-eslint/eslint-plugin": "^7.7.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.12"
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
     "start": "node dist/main.js",
     "build": "tsc -p tsconfig.json",
     "start:dev": "ts-node-dev --respawn --transpile-only src/main.ts",
-    "lint": "eslint .",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "jest",
     "migrate": "bash -c 'for f in migrations/*.sql; do echo Running $f; psql \"$DATABASE_URL\" -v ON_ERROR_STOP=1 -f \"$f\"; done'"
   },

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,7 @@
     "@typescript-eslint/eslint-plugin": "^7.7.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
-    "@types/jest": "^29.5.12"
+    "@types/jest": "^29.5.12",
+    "@eslint/js": "^8.57.0"
   }
 }

--- a/backend/src/app.module.spec.ts
+++ b/backend/src/app.module.spec.ts
@@ -1,0 +1,7 @@
+import { AppModule } from './app.module';
+
+describe('AppModule', () => {
+  it('should be defined', () => {
+    expect(AppModule).toBeDefined();
+  });
+});

--- a/frontend/eslint.config.cjs
+++ b/frontend/eslint.config.cjs
@@ -1,0 +1,8 @@
+const next = require('eslint-config-next');
+
+module.exports = [
+  {
+    ignores: ['node_modules/**'],
+  },
+  next,
+];

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,10 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({ dir: './' });
+
+const customJestConfig = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "lint": "eslint src --ext .ts,.tsx",
+    "test": "jest"
   },
   "dependencies": {
     "next": "^14.2.4",
@@ -18,6 +20,17 @@
     "lucide-react": "^0.446.0",
     "tailwindcss": "^3.4.4",
     "@tailwindcss/forms": "^0.5.7"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.4",
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.4.1",
+    "@testing-library/user-event": "^14.4.3",
+    "@types/jest": "^29.5.12",
+    "@types/react": "^18.2.8",
+    "@types/react-dom": "^18.2.4",
+    "typescript": "^5.4.5"
   }
 }
-

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint src --ext .ts,.tsx",
+    "lint": "next lint",
     "test": "jest"
   },
   "dependencies": {

--- a/frontend/src/components/UploadArea.test.tsx
+++ b/frontend/src/components/UploadArea.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import UploadArea from './UploadArea';
+
+describe('UploadArea', () => {
+  it('renders drag & drop text', () => {
+    render(<UploadArea onPresigned={() => {}} />);
+    expect(screen.getByText(/Drag & drop/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- configure ESLint and Jest for backend and frontend
- add smoke tests for NestJS module and UploadArea component
- run lint and test in GitHub Actions CI
- restore database migration script in backend package.json

## Testing
- `npm install --no-package-lock` (fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest)
- `npm test` (backend) *(fails: jest: not found)*
- `npm run lint` (backend) *(fails: Cannot find module '@eslint/js')*
- `npm test` (frontend) *(fails: jest: not found)*
- `npm run lint` (frontend) *(fails: Cannot find module 'eslint-config-next')*


------
https://chatgpt.com/codex/tasks/task_e_68983decb68c832982dae4839e7a887b