### PR TITLE
Parse S3 endpoint URL for Minio client

### DIFF
--- a/backend/src/modules/storage/storage.service.ts
+++ b/backend/src/modules/storage/storage.service.ts
@@ -7,10 +7,13 @@ export class StorageService {
   private readonly client: MinioClient;
 
   constructor() {
+    const url = new URL(cfg.s3.endpoint);
+    const port = url.port ? parseInt(url.port, 10) : 9000;
+
     this.client = new MinioClient({
-      endpoint: cfg.s3.endpoint.split('//')[1],
-      port: cfg.s3.endpoint.startsWith('https') ? 443 : 80,
-      useSSL: cfg.s3.endpoint.startsWith('https'),
+      endPoint: url.hostname,
+      port,
+      useSSL: url.protocol === 'https:',
       accessKey: cfg.s3.accessKey,
       secretKey: cfg.s3.secretKey,
     });


### PR DESCRIPTION
## Summary
- Parse S3 endpoint with `URL` to extract host and port for Minio client
- Default to MinIO's standard port when none is specified

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: TypeScript errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68984cfdf7588329a5419f381e229a73