### PR TITLE
fix(storage): normalize chunk types

### DIFF
--- a/backend/src/modules/storage/storage.service.ts
+++ b/backend/src/modules/storage/storage.service.ts
@@ -30,7 +30,7 @@ export class StorageService {
           return reject(err);
         }
         stream.on('data', (chunk) => {
-          chunks.push(chunk);
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
         });
         stream.on('end', () => {
           resolve(Buffer.concat(chunks));


### PR DESCRIPTION
## Summary
- ensure streamed data chunks are buffers in `getOrRejectBuffer`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68984d0397b883299417f0c6a81260ea