### PR TITLE
fix storage service presigned put object header

### DIFF
--- a/backend/src/modules/storage/storage.service.ts
+++ b/backend/src/modules/storage/storage.service.ts
@@ -17,8 +17,8 @@ export class StorageService {
   }
 
   async presignedPutObject(key: string, mime: string): Promise<string> {
-    return await this.client.presignedPutObject(cfg.s3.bucket, key, 60 * 10, {
-      'content-type': mime,
+    return this.client.presignedPutObject(cfg.s3.bucket, key, 60 * 10, {
+      'Content-Type': mime,
     });
   }
 


### PR DESCRIPTION
## Summary
- Return Minio `presignedPutObject` promise directly
- Use standard `Content-Type` header casing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: eslint: not found)*
- `npx eslint .` *(fails: 403 Forbidden for eslint package)*

------
https://chatgpt.com/codex/tasks/task_e_68984d024e088329b0d550af634a9dc2