### PR TITLE
feat: add guarded getObjectBuffer

### DIFF
--- a/backend/src/modules/storage/storage.service.ts
+++ b/backend/src/modules/storage/storage.service.ts
@@ -25,23 +25,55 @@ export class StorageService {
     });
   }
 
-  async getOrRejectBuffer(key: string): Promise<Buffer> {
+  async getObjectBuffer(
+    key: string,
+    { maxSize, timeoutMs }: { maxSize?: number; timeoutMs?: number } = {},
+  ): Promise<Buffer> {
     return new Promise<Buffer>((resolve, reject) => {
       const chunks: Buffer[] = [];
-      this.client.getObject(cfg.s3.bucket, key, (err, stream) => {
-        if (err) {
-          return reject(err);
-        }
-        stream.on('data', (chunk) => {
-          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      let totalSize = 0;
+      let timer: NodeJS.Timeout | undefined;
+
+      try {
+        this.client.getObject(cfg.s3.bucket, key, (err, stream) => {
+          if (err) {
+            return reject(err);
+          }
+
+          if (timeoutMs) {
+            timer = setTimeout(() => {
+              stream.destroy(new Error('Stream timeout'));
+              reject(new Error('Stream timeout'));
+            }, timeoutMs);
+          }
+
+          stream.on('data', (chunk: Buffer | Uint8Array | string) => {
+            const bufferChunk = Buffer.isBuffer(chunk)
+              ? chunk
+              : Buffer.from(chunk);
+            totalSize += bufferChunk.length;
+            if (maxSize && totalSize > maxSize) {
+              stream.destroy(new Error('Max size exceeded'));
+              if (timer) clearTimeout(timer);
+              return reject(new Error('Max size exceeded'));
+            }
+            chunks.push(bufferChunk);
+          });
+
+          stream.on('end', () => {
+            if (timer) clearTimeout(timer);
+            resolve(Buffer.concat(chunks));
+          });
+
+          stream.on('error', (error) => {
+            if (timer) clearTimeout(timer);
+            reject(error);
+          });
         });
-        stream.on('end', () => {
-          resolve(Buffer.concat(chunks));
-        });
-        stream.on('error', (error) => {
-          reject(error);
-        });
-      });
+      } catch (error) {
+        if (timer) clearTimeout(timer);
+        reject(error);
+      }
     });
   }
 }


### PR DESCRIPTION
## Summary
- handle pre-stream errors in storage service
- normalize streamed chunks and add optional max-size/timeout guards

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*

------
https://chatgpt.com/codex/tasks/task_e_689853b5516083298314bc87e98739b4