### PR TITLE
Refactor readings service and declare fetch global

### DIFF
--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -1,0 +1,12 @@
+export default [
+  {
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'module',
+      globals: {
+        fetch: 'readonly',
+        process: 'readonly',
+      },
+    },
+  },
+];

--- a/backend/src/modules/readings/readings.service.ts
+++ b/backend/src/modules/readings/readings.service.ts
@@ -98,18 +98,5 @@ export class ReadingsService {
       model: 'rule-based-demo',
     };
   }
-
-  async interpret(dto: InterpretationRequest): Promise<InterpretationResult> {
-    // Placeholder interpretation logic
-    const summary = `Interpretation for ${dto.cards
-      .map((c) => c.name)
-      .join(', ')} in deck ${dto.deck}`;
-    return {
-      id: randomUUID(),
-      summary,
-      full_text: summary + '. (demo)',
-      model: 'rule-based-demo',
-    };
-  }
 }
 


### PR DESCRIPTION
## Summary
- remove duplicate `interpret` method in readings service
- configure ESLint to recognize global `fetch`

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module './modules/mail/mail.service', missing type declarations, decorators not valid, etc.)*
- `node -e "console.log(process.version); console.log(typeof fetch)"`


------
https://chatgpt.com/codex/tasks/task_e_68985c307f1083299a00996107a924c4