### PR TITLE
chore: clean up unused backend code

### DIFF
--- a/backend/src/modules/pdf/pdf.service.ts
+++ b/backend/src/modules/pdf/pdf.service.ts
@@ -24,7 +24,7 @@ export class PdfService {
     // Dimensions for an A4 page in PDF points
     const page = pdfDoc.addPage([595.28, 841.89]);
     const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
-    const { width, height } = page.getSize();
+    const { height } = page.getSize();
 
     // Draw logo at the top left
     try {

--- a/backend/src/modules/readings/readings.controller.ts
+++ b/backend/src/modules/readings/readings.controller.ts
@@ -1,7 +1,6 @@
 import {
   Body,
   Controller,
-  ForbiddenException,
   Get,
   Param,
   Post,

--- a/backend/src/modules/readings/readings.service.ts
+++ b/backend/src/modules/readings/readings.service.ts
@@ -4,9 +4,9 @@ import { cfg } from '../../common/config';
 import { randomUUID } from 'crypto';
 
 export interface DetectedCard {
-  name: string;
-  orientation: 'upright' | 'reversed';
-  confidence: number;
+  name: string;
+  orientation: 'upright' | 'reversed';
+  confidence: number;
 }
 
 export interface InterpretationRequest {

--- a/backend/src/modules/sessions/sessions.controller.ts
+++ b/backend/src/modules/sessions/sessions.controller.ts
@@ -4,7 +4,6 @@ import {
   Get,
   Param,
   Post,
-  Res,
   UseGuards,
 } from '@nestjs/common';
 import { SessionsService } from './sessions.service';


### PR DESCRIPTION
## Summary
- remove unused width variable from PDF service
- drop unused imports from readings and sessions controllers
- normalize whitespace in DetectedCard interface

## Testing
- `npm --prefix backend run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68985c2e83788329adf05f4ef6bab38a