### PR TITLE
refactor: replace any with specific types

### DIFF
--- a/backend/src/common/db.ts
+++ b/backend/src/common/db.ts
@@ -5,6 +5,6 @@ export const pool = new pg.Pool({
   connectionString: cfg.db.url,
 });
 
-export const query = <T = any>(text: string, params?: any[]) =>
+export const query = <T = unknown>(text: string, params?: unknown[]) =>
   pool.query<T>(text, params);
 

--- a/backend/src/common/guards/auth.guard.ts
+++ b/backend/src/common/guards/auth.guard.ts
@@ -7,7 +7,9 @@ export class AuthGuard implements CanActivate {
   constructor(private readonly auth: AuthService) {}
 
   canActivate(context: ExecutionContext): boolean {
-    const req = context.switchToHttp().getRequest<Request>();
+    const req = context
+      .switchToHttp()
+      .getRequest<Request & { user?: ReturnType<AuthService['verify']> }>();
     const header = req.headers['authorization'];
     if (!header || !header.startsWith('Bearer ')) {
       throw new UnauthorizedException();
@@ -15,7 +17,7 @@ export class AuthGuard implements CanActivate {
     const token = header.slice(7);
     try {
       const payload = this.auth.verify(token);
-      (req as any).user = payload;
+      req.user = payload;
       return true;
     } catch {
       throw new UnauthorizedException();

--- a/backend/src/common/guards/roles.guard.ts
+++ b/backend/src/common/guards/roles.guard.ts
@@ -1,5 +1,11 @@
-import { CanActivate, ExecutionContext, Injectable, ForbiddenException } from '@nestjs/common';
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  ForbiddenException,
+} from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
 import { Role } from '../roles.decorator';
 
 @Injectable()
@@ -13,8 +19,10 @@ export class RolesGuard implements CanActivate {
     if (!roles || roles.length === 0) {
       return true;
     }
-    const req = context.switchToHttp().getRequest();
-    const user = (req as any).user as { role: Role } | undefined;
+    const req = context
+      .switchToHttp()
+      .getRequest<Request & { user?: { role: Role } }>();
+    const user = req.user;
     if (user && roles.includes(user.role)) {
       return true;
     }

--- a/backend/src/modules/pdf/pdf.service.ts
+++ b/backend/src/modules/pdf/pdf.service.ts
@@ -2,6 +2,16 @@ import { Injectable } from '@nestjs/common';
 import { PDFDocument, StandardFonts } from 'pdf-lib';
 import { ReadingsService } from '../readings/readings.service';
 
+interface CardThumb {
+  thumbnail?: Buffer;
+}
+
+interface ReadingWithCards {
+  summary: string;
+  full_text?: string | null;
+  cards?: CardThumb[];
+}
+
 // 1x1 transparent PNG used as a fallback logo/card image
 const PLACEHOLDER_IMG = Buffer.from(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9W410wAAAABJRU5ErkJggg==',
@@ -44,7 +54,7 @@ export class PdfService {
     }
 
     // Card thumbnails (if available)
-    const cards: any[] = (reading as any).cards || [];
+    const cards: CardThumb[] = (reading as ReadingWithCards).cards ?? [];
     if (cards.length) {
       y -= 170; // leave some space after text
       let x = 40;

--- a/backend/src/modules/sessions/sessions.controller.ts
+++ b/backend/src/modules/sessions/sessions.controller.ts
@@ -19,7 +19,7 @@ export class SessionsController {
   constructor(private readonly svc: SessionsService) {}
 
   @Post()
-  async create(@Body() dto: any) {
+  async create(@Body() dto: { client_id: string }) {
     return this.svc.create(dto);
   }
 


### PR DESCRIPTION
## Summary
- replace loose any usage in database query helper with unknown typings
- add typed request user payload in auth and roles guards
- model PDF reading cards and sessions payload with explicit interfaces

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68985c2ca1b0832984c04e15e4f907c9