### PR TITLE
feat: add listByClient for sessions

### DIFF
--- a/backend/src/modules/sessions/sessions.controller.ts
+++ b/backend/src/modules/sessions/sessions.controller.ts
@@ -29,6 +29,7 @@ export class SessionsController {
 
   @Get('client/:clientId')
   async listByClient(@Param('clientId') clientId: string) {
+    // Delegate fetching of sessions to the service layer
     return this.svc.listByClient(clientId);
   }
 }

--- a/backend/src/modules/sessions/sessions.service.ts
+++ b/backend/src/modules/sessions/sessions.service.ts
@@ -42,7 +42,11 @@ export class SessionsService {
     return rows[0];
   }
 
-  async list(clientId: string): Promise<Session[]> {
+  /**
+   * Return all sessions belonging to a specific client ordered by creation date
+   * (most recent first).
+   */
+  async listByClient(clientId: string): Promise<Session[]> {
     const { rows } = await this.db.query(
       'SELECT id, client_id, created_at FROM sessions WHERE client_id = $1 ORDER BY created_at DESC',
       [clientId],


### PR DESCRIPTION
## Summary
- add `listByClient` to SessionsService to fetch sessions scoped to a client
- ensure controller delegates to the new service method

## Testing
- `npm test` *(fails: Cannot find module './modules/mail/mail.service')*

------
https://chatgpt.com/codex/tasks/task_e_689867c253c48329a264bf1d8b264aaf