### PR TITLE
Expand backend role definitions and normalize annotations

### DIFF
--- a/backend/src/common/roles.decorator.ts
+++ b/backend/src/common/roles.decorator.ts
@@ -1,4 +1,4 @@
 import { SetMetadata } from '@nestjs/common';
 
-export type Role = 'owner' | 'assistant';
+export type Role = 'owner' | 'assistant' | 'manager' | 'client';
 export const Roles = (...roles: Role[]) => SetMetadata('roles', roles);

--- a/backend/src/modules/readings/readings.controller.ts
+++ b/backend/src/modules/readings/readings.controller.ts
@@ -23,13 +23,13 @@ export class ReadingsController {
   ) {}
 
   @Get(':id')
-  @Roles('Assistant')
+  @Roles('assistant')
   async get(@Param('id') id: string) {
     return this.svc.get(id);
   }
 
   @Post()
-  @Roles('Manager', 'Assistant')
+  @Roles('manager', 'assistant')
   async createFromVision(
     @Body() body: { cards: { name: string; orientation: string }[] },
   ) {


### PR DESCRIPTION
## Summary
- expand Role union to include client and manager roles
- use lowercase role strings in readings controller
- roles guard relies on Role union to authorize expanded set

## Testing
- `npm test` *(fails: Cannot find module './modules/mail/mail.service')*
- `npm run lint` *(fails: All files matching pattern `{src,apps,libs,test}/**/*.ts` are ignored)*

------
https://chatgpt.com/codex/tasks/task_e_689867c0cecc832981c4eb3406278434