### PR TITLE
refactor: fix guard imports

### DIFF
--- a/backend/src/modules/clients/clients.controller.ts
+++ b/backend/src/modules/clients/clients.controller.ts
@@ -6,11 +6,11 @@ import {
   NotFoundException,
   Param,
   Post,
+  UseGuards,
 } from '@nestjs/common';
-import { UseGuards } from '@nestjs/common';
-import { AuthGuard } from '../common/guards/auth.guard';
-import { RolesGuard } from '../common/guards/roles.guard';
-import { Roles } from '../common/decorators/roles.decorator';
+import { AuthGuard } from '../../common/guards/auth.guard';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { Roles } from '../../common/roles.decorator';
 
 import { ClientsService } from './clients.service';
 

--- a/backend/src/modules/readings/readings.controller.ts
+++ b/backend/src/modules/readings/readings.controller.ts
@@ -10,9 +10,9 @@ import {
 import { Response } from 'express';
 import { ReadingsService } from './readings.service';
 import { PdfService } from '../pdf/pdf.service';
-import { AuthGuard } from '../common/guards/auth.guard';
-import { RolesGuard } from '../common/guards/roles.guard';
-import { Roles } from '../common/decorators/roles.decorator';
+import { AuthGuard } from '../../common/guards/auth.guard';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { Roles } from '../../common/roles.decorator';
 
 @Controller('readings')
 @UseGuards(AuthGuard, RolesGuard)

--- a/backend/src/modules/sessions/sessions.controller.ts
+++ b/backend/src/modules/sessions/sessions.controller.ts
@@ -7,9 +7,9 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { SessionsService } from './sessions.service';
-import { AuthGuard } from '../common/guards/auth.guard';
-import { RolesGuard } from '../common/guards/roles.guard';
-import { Roles } from '../common/decorators/roles.decorator';
+import { AuthGuard } from '../../common/guards/auth.guard';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { Roles } from '../../common/roles.decorator';
 
 @Controller('sessions')
 @UseGuards(AuthGuard, RolesGuard)


### PR DESCRIPTION
## Summary
- normalize guard and decorator imports to `../../common` paths in module controllers
- consolidate `UseGuards` imports to remove redundancy

## Testing
- `npm test` *(fails: Cannot find module './modules/mail/mail.service')*

------
https://chatgpt.com/codex/tasks/task_e_689867bfb94c8329a982408d3b99f069