### PR TITLE
fix: use valid minio package version

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,7 @@
     "uuid": "^9.0.1",
     "nodemailer": "^6.9.12",
     "pg": "^8.11.5",
-    "minio": "^8.8.1"
+    "minio": "^8.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",


### PR DESCRIPTION
## Summary
- fix package.json to use a valid minio package version

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find module 'globals')*


------
https://chatgpt.com/codex/tasks/task_e_689866d56ab48329859995f101e74fe5