### PR TITLE
Restrict roles to owner and assistant

### DIFF
--- a/backend/src/common/roles.decorator.ts
+++ b/backend/src/common/roles.decorator.ts
@@ -1,4 +1,4 @@
 import { SetMetadata } from '@nestjs/common';
 
-export type Role = 'owner' | 'assistant' | 'manager' | 'client';
+export type Role = 'owner' | 'assistant';
 export const Roles = (...roles: Role[]) => SetMetadata('roles', roles);

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -12,6 +12,9 @@ export class AuthService {
   private readonly secret = cfg.auth.jwtSecret;
 
   issue(role: Role) {
+    if (!['owner', 'assistant'].includes(role)) {
+      throw new Error('unsupported role');
+    }
     const header = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
     const payload = base64url(
       JSON.stringify({ role, exp: Math.floor(Date.now() / 1000) + 60 * 60 })

--- a/backend/src/modules/clients/clients.controller.ts
+++ b/backend/src/modules/clients/clients.controller.ts
@@ -16,7 +16,7 @@ import { ClientsService } from './clients.service';
 
 @Controller('clients')
 @UseGuards(AuthGuard, RolesGuard)
-@Roles('client')
+@Roles('owner', 'assistant')
 export class ClientsController {
   constructor(private readonly svc: ClientsService) {}
 

--- a/backend/src/modules/readings/readings.controller.ts
+++ b/backend/src/modules/readings/readings.controller.ts
@@ -23,13 +23,13 @@ export class ReadingsController {
   ) {}
 
   @Get(':id')
-  @Roles('assistant')
+  @Roles('owner', 'assistant')
   async get(@Param('id') id: string) {
     return this.svc.get(id);
   }
 
   @Post()
-  @Roles('manager', 'assistant')
+  @Roles('owner', 'assistant')
   async createFromVision(
     @Body() body: { cards: { name: string; orientation: string }[] },
   ) {

--- a/backend/src/modules/sessions/sessions.controller.ts
+++ b/backend/src/modules/sessions/sessions.controller.ts
@@ -13,7 +13,7 @@ import { Roles } from '../../common/roles.decorator';
 
 @Controller('sessions')
 @UseGuards(AuthGuard, RolesGuard)
-@Roles('manager')
+@Roles('owner', 'assistant')
 export class SessionsController {
   constructor(private readonly svc: SessionsService) {}
 

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -4,6 +4,8 @@
     "target": "es2021",
     "strict": true,
     "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
## Summary
- enforce JWT issuance only for owner and assistant roles
- align clients, sessions, and readings controllers with owner/assistant role set
- enable TypeScript decorator support via tsconfig

## Testing
- `npm test` *(fails: Could not find a declaration file for module 'express')*
- `npm install --no-save @types/express` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6898725f9fb083299ab493994c739521