### PR TITLE
Restrict auth token roles to owner and assistant

### DIFF
--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -9,6 +9,9 @@ export class AuthController {
 
   @Post('token')
   async token(@Body() dto: { role: Role; password: string }) {
+    if (dto.role !== 'owner' && dto.role !== 'assistant') {
+      throw new UnauthorizedException();
+    }
     const expected =
       dto.role === 'owner' ? cfg.auth.ownerPassword : cfg.auth.assistantPassword;
     if (dto.password !== expected) {


### PR DESCRIPTION
## Summary
- limit token issuance to owner and assistant roles
- reject invalid roles before verifying passwords

## Testing
- `npm test` *(fails: Decorators are not valid here in clients.controller.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689872b8c56883299416a0ddf1ea7d88