### PR TITLE
feat: harden JWT verification

### DIFF
--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -28,6 +28,20 @@ export class AuthService {
     if (!h || !p || !s) {
       throw new Error('invalid token');
     }
+
+    let header: { alg: string };
+    let payload: { role?: Role; exp?: number };
+    try {
+      header = JSON.parse(Buffer.from(h, 'base64url').toString());
+      payload = JSON.parse(Buffer.from(p, 'base64url').toString());
+    } catch {
+      throw new Error('invalid token');
+    }
+
+    if (header.alg !== 'HS256') {
+      throw new Error('unsupported algorithm');
+    }
+
     const data = `${h}.${p}`;
     const expected = createHmac('sha256', this.secret)
       .update(data)
@@ -35,10 +49,15 @@ export class AuthService {
     if (s !== expected) {
       throw new Error('invalid signature');
     }
-    const payload = JSON.parse(Buffer.from(p, 'base64url').toString());
+
     if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {
       throw new Error('token expired');
     }
+
+    if (!payload.role) {
+      throw new Error('invalid token');
+    }
+
     return { role: payload.role };
   }
 }


### PR DESCRIPTION
## Summary
- add explicit checks for JWT header and payload when verifying tokens

## Testing
- `npm test` *(fails: src/modules/clients/clients.controller.ts:23:3 - error TS1241: Unable to resolve signature of method decorator when called as an expression)*

------
https://chatgpt.com/codex/tasks/task_e_689872c491e08329a1b331ad17c3dc2e