### PR TITLE
feat: add html content to email service

### DIFF
--- a/backend/src/modules/email/email.service.ts
+++ b/backend/src/modules/email/email.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import * as nodemailer from 'nodemailer';
+import nodemailer from 'nodemailer';
 import { cfg } from '../../common/config';
 
 @Injectable()
 export class EmailService {
-  private transporter = nodemailer.createTransport({
+  private readonly transporter = nodemailer.createTransport({
     host: cfg.smtp.host,
     port: 587,
     secure: false,
@@ -21,17 +21,21 @@ export class EmailService {
     body: string,
     opts?: { pdf?: Buffer; link?: string },
   ) {
-    const mail = {
+    const text = opts?.link ? `${body}\n${opts.link}` : body;
+    const html = opts?.link
+      ? `${body.replace(/\n/g, '<br>')}<br><a href="${opts.link}">${opts.link}</a>`
+      : body.replace(/\n/g, '<br>');
+
+    await this.transporter.sendMail({
       from: cfg.smtp.user,
       to,
       subject,
-      text: opts?.link ? `${body}\n${opts.link}` : body,
+      text,
+      html,
       attachments: opts?.pdf
         ? [{ filename: 'reading.pdf', content: opts.pdf }]
         : undefined,
-    };
-
-    await this.transporter.sendMail(mail);
+    });
     return { to, subject };
   }
 }


### PR DESCRIPTION
## Summary
- send emails with both text and HTML bodies
- format optional links as clickable anchors

## Testing
- `npm test` (fails: Unable to resolve signature of method decorator when called as an expression)
- `npm run lint` (fails: Cannot find module 'typescript-eslint')

------
https://chatgpt.com/codex/tasks/task_e_689872f66a708329abd466b4801e0276