### PR TITLE
refactor: reuse common db pool in sessions service

### DIFF
--- a/backend/src/modules/sessions/sessions.service.ts
+++ b/backend/src/modules/sessions/sessions.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { Pool } from 'pg';
 import { randomUUID } from 'crypto';
-import { cfg } from '../../common/config';
+import { query } from '../../common/db';
 
 interface Session {
   id: string;
@@ -11,15 +10,10 @@ interface Session {
 
 @Injectable()
 export class SessionsService {
-  private db: Pool;
-
-  constructor() {
-    this.db = new Pool({ connectionString: cfg.db.url });
-  }
 
   async create(dto: { client_id: string }): Promise<Session> {
     // Ensure the client exists to satisfy FK constraints
-    const client = await this.db.query('SELECT id FROM clients WHERE id = $1', [
+    const client = await query('SELECT id FROM clients WHERE id = $1', [
       dto.client_id,
     ]);
     if (client.rowCount === 0) {
@@ -27,7 +21,7 @@ export class SessionsService {
     }
 
     const id = randomUUID();
-    const { rows } = await this.db.query(
+    const { rows } = await query<Session>(
       'INSERT INTO sessions (id, client_id, created_at) VALUES ($1, $2, NOW()) RETURNING *',
       [id, dto.client_id],
     );
@@ -35,7 +29,7 @@ export class SessionsService {
   }
 
   async get(id: string): Promise<Session | undefined> {
-    const { rows } = await this.db.query(
+    const { rows } = await query<Session>(
       'SELECT id, client_id, created_at FROM sessions WHERE id = $1',
       [id],
     );
@@ -47,7 +41,7 @@ export class SessionsService {
    * (most recent first).
    */
   async listByClient(clientId: string): Promise<Session[]> {
-    const { rows } = await this.db.query(
+    const { rows } = await query<Session>(
       'SELECT id, client_id, created_at FROM sessions WHERE client_id = $1 ORDER BY created_at DESC',
       [clientId],
     );


### PR DESCRIPTION
## Summary
- reuse shared database pool via common query helper in SessionsService

## Testing
- `npm test` (fails: Unable to resolve signature of method decorator...)
- `npm run lint` (fails: Cannot find module 'typescript-eslint')

------
https://chatgpt.com/codex/tasks/task_e_6898730d11c88329aa4b5147c0b41724