### PR TITLE
feat: add major arcana images and tarot card component

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-public/tarot/*.gif filter=lfs diff=lfs merge=lfs -text
+public/tarot/*.jpg filter=lfs diff=lfs merge=lfs -text

--- a/public/tarot/death.jpg
+++ b/public/tarot/death.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06c851155efdbccf0fed42a6a1e95e4b0bc49429f6f96b8e054be53d463f9ccd
+size 88921

--- a/public/tarot/judgement.jpg
+++ b/public/tarot/judgement.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7036b0d33c507ee37405105e97da79840cb1e0c05c25769691f601fb9334b1b
+size 89915

--- a/public/tarot/justice.jpg
+++ b/public/tarot/justice.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e9360bc6f09c81db2ff48a9a5b4e4b4ec296ad3071258bb1d36d2d98f5eb434
+size 88872

--- a/public/tarot/placeholder.gif
+++ b/public/tarot/placeholder.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3331a0486cb3e8a75c8c2fdf02bf80fd8fe2b811dfe5c7b4aa892d38bfcf604a
-size 43

--- a/public/tarot/strength.jpg
+++ b/public/tarot/strength.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:762bcdd98291a40163e7fde6f05edc743521f4a4b843297f18bf1da2148fbe19
+size 75974

--- a/public/tarot/temperance.jpg
+++ b/public/tarot/temperance.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0592bb39d8e332f0e2772819b4492cbd6f98b3b138de72e26ef4d1b635d23bcf
+size 91483

--- a/public/tarot/the_chariot.jpg
+++ b/public/tarot/the_chariot.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c18bed5a9317217f3bc19fc1dee10037f4ca92883e4f74e324f5c9c13c3175dc
+size 88325

--- a/public/tarot/the_devil.jpg
+++ b/public/tarot/the_devil.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2488bb5403edf0fa38c300cd9365d3291e769e988823096f12f8b2897f577e48
+size 79921

--- a/public/tarot/the_emperor.jpg
+++ b/public/tarot/the_emperor.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38923dfb9960e1d96594f404d099e3a41dbca90c56ab1dee421de0eb99c7bb7c
+size 88501

--- a/public/tarot/the_empress.jpg
+++ b/public/tarot/the_empress.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:522f2b15e46b4ccf11b38f76d6a4e59f137cf8b16c015eb417a53ba5e099b58c
+size 93786

--- a/public/tarot/the_fool.jpg
+++ b/public/tarot/the_fool.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84763e72e4e147d923b3b73db6f142bc2d2af38058190317e1c7d137aefca42f
+size 106521

--- a/public/tarot/the_hanged_man.jpg
+++ b/public/tarot/the_hanged_man.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1672e373440da90f17a007d6120982691949f96feb82656edeb41ace7054421
+size 94574

--- a/public/tarot/the_hermit.jpg
+++ b/public/tarot/the_hermit.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51e386f674ab76cb6a37506c875a9f8196a950bea1c0f2599dcd36f6c7f2edf1
+size 64645

--- a/public/tarot/the_hierophant.jpg
+++ b/public/tarot/the_hierophant.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6a04fa54f3057045e8cb0c284a4a5b893c1c8265442b6afed54f36beabd53c6
+size 90484

--- a/public/tarot/the_high_priestess.jpg
+++ b/public/tarot/the_high_priestess.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bde39c2607821f4be0ede2ab3310ae0c77ffa21f1eded1e1b40ffb70c15664ac
+size 84883

--- a/public/tarot/the_lovers.jpg
+++ b/public/tarot/the_lovers.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12bb6866a6f578afd7cd9c160ecbe8854227dc8791f808d91a190baca7a7faf1
+size 92247

--- a/public/tarot/the_magician.jpg
+++ b/public/tarot/the_magician.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68f626b5843fe8130d99f3cf10ebc9958ddd3fc23434c4392f27eaadb4db6db8
+size 81869

--- a/public/tarot/the_moon.jpg
+++ b/public/tarot/the_moon.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:823b1273325f210593fdc1a1b5aa7040383b1b402821886fdfa292deb677555a
+size 83667

--- a/public/tarot/the_star.jpg
+++ b/public/tarot/the_star.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6aeb3132cdb13fd528e522c7e4802bd6c18fb0d5c492f833195d4ef0797343bd
+size 82000

--- a/public/tarot/the_sun.jpg
+++ b/public/tarot/the_sun.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fd1a372c948894166262a669b98bde901316b1c53d021c338a0a9b99efa0906
+size 93585

--- a/public/tarot/the_tower.jpg
+++ b/public/tarot/the_tower.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17e29649492263f48405bbf8f9df39ba7e236b78158bf3d0d5ed420f5f6adf40
+size 79788

--- a/public/tarot/the_world.jpg
+++ b/public/tarot/the_world.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da8dda292f21ac85270ad90fc4895139627367d5859c80299f952e7a8af0c33b
+size 109195

--- a/public/tarot/wheel_of_fortune.jpg
+++ b/public/tarot/wheel_of_fortune.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:476f56be90eb473bc730bb6580f4f070a7cfcc3f94326a291d708e352948d6cd
+size 108917

--- a/src/components/tarot-card.tsx
+++ b/src/components/tarot-card.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+// Mapping of major arcana card identifiers to image paths in /public
+export const MAJOR_ARCANA: Record<string, string> = {
+  the_fool: "/tarot/the_fool.jpg",
+  the_magician: "/tarot/the_magician.jpg",
+  the_high_priestess: "/tarot/the_high_priestess.jpg",
+  the_empress: "/tarot/the_empress.jpg",
+  the_emperor: "/tarot/the_emperor.jpg",
+  the_hierophant: "/tarot/the_hierophant.jpg",
+  the_lovers: "/tarot/the_lovers.jpg",
+  the_chariot: "/tarot/the_chariot.jpg",
+  strength: "/tarot/strength.jpg",
+  the_hermit: "/tarot/the_hermit.jpg",
+  wheel_of_fortune: "/tarot/wheel_of_fortune.jpg",
+  justice: "/tarot/justice.jpg",
+  the_hanged_man: "/tarot/the_hanged_man.jpg",
+  death: "/tarot/death.jpg",
+  temperance: "/tarot/temperance.jpg",
+  the_devil: "/tarot/the_devil.jpg",
+  the_tower: "/tarot/the_tower.jpg",
+  the_star: "/tarot/the_star.jpg",
+  the_moon: "/tarot/the_moon.jpg",
+  the_sun: "/tarot/the_sun.jpg",
+  judgement: "/tarot/judgement.jpg",
+  the_world: "/tarot/the_world.jpg",
+};
+
+export interface TarotCardProps {
+  /**
+   * The key of the card in `MAJOR_ARCANA`.
+   */
+  card: keyof typeof MAJOR_ARCANA;
+  /** Optional alt text for the image */
+  alt?: string;
+  /** Optional additional class name */
+  className?: string;
+}
+
+/**
+ * Renders a tarot card image from the `public/tarot` directory.
+ */
+export function TarotCard({ card, alt, className }: TarotCardProps) {
+  const src = MAJOR_ARCANA[card];
+  return <img src={src} alt={alt ?? card.replace(/_/g, " ")} className={className} />;
+}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -92,5 +93,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add 22 major arcana images with predictable filenames
- introduce TarotCard component and mapping to new assets
- track tarot images with Git LFS and resolve lint errors in shared UI code

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a37ed36b3c8329b0e555242bad0693