### PR TITLE
refactor: replace interface with type alias

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -23,9 +23,9 @@ const badgeVariants = cva(
   },
 );
 
-export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof badgeVariants> {}
+export type BadgeProps =
+  React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof badgeVariants>;
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (


### PR DESCRIPTION
## Summary
- refactor badge props to use type alias instead of interface

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3e617114c8329a2fb3149c1452113