### PR TITLE
feat: add theme toggle to landing page

### DIFF
--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export const ThemeToggle = () => {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", isDark);
+  }, [isDark]);
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => setIsDark((prev) => !prev)}
+    >
+      <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,19 +1,21 @@
-// Update this page (the content is just a fallback if you fail to update the page)
-
+import { ThemeToggle } from "@/components/theme-toggle";
 import { MadeWithDyad } from "@/components/made-with-dyad";
 
 const Index = () => {
   return (
-    <div className="flex items-center justify-center p-8 bg-gray-100">
+    <div className="relative flex min-h-screen items-center justify-center p-8 bg-gray-100">
+      <div className="absolute top-4 right-4">
+        <ThemeToggle />
+      </div>
       <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">
-          Welcome to Your Blank App
-        </h1>
+        <h1 className="mb-4 text-4xl font-bold">Welcome to Your Blank App</h1>
         <p className="text-xl text-gray-600">
           Start building your amazing project here!
         </p>
       </div>
-      <MadeWithDyad />
+      <div className="absolute bottom-4 left-1/2 -translate-x-1/2">
+        <MadeWithDyad />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- clean up landing page and add theme toggle
- render MadeWithDyad footer

## Testing
- `npx eslint src/pages/Index.tsx src/components/theme-toggle.tsx && echo "lint passed"`


------
https://chatgpt.com/codex/tasks/task_e_68a3ea701ec48329bf338e3ab61c06f1